### PR TITLE
fix(main): disconnect networks early on "stop"

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,7 +188,7 @@ def monitor_events():
 
     # Define the Docker events to track for managing Traefik connections
     tracked_events = {
-        "container": ["start", "die"],
+        "container": ["start", "stop", "die"],
     }
 
     # Listen to Docker events in real-time
@@ -234,9 +234,15 @@ def monitor_events():
                     app_logger.info(f"Container {container.name} is being created. Attempting to connect Traefik to relevant networks.")
                     connect_traefik_to_network(container)
 
+                elif event["Action"] == "stop":
+                    app_logger.info(
+                        f"Container {container.name} is being stopped. Attempting to disconnect Traefik from relevant networks."
+                    )
+                    disconnect_traefik_from_network(container)
+
                 elif event["Action"] == "die":
                     app_logger.info(
-                        f"Container {container.name} is being killed. Attempting to disconnect Traefik to relevant networks."
+                        f"Container {container.name} is being killed. Attempting to disconnect Traefik from relevant networks."
                     )
                     disconnect_traefik_from_network(container)
                     del container_cache[event["id"]]


### PR DESCRIPTION
This reduces the chance of having dangling networks left. This can happen if all services are removed from a network and the network is automatically removed as is the case with e.g. "docker compose down". If Traefik does not leave a network quickly enough, the network is left unchanged because it is still "in use".